### PR TITLE
Add soloud submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ResourcePackager/Dependencies/assimp"]
 	path = ResourcePackager/Dependencies/assimp
 	url = https://github.com/assimp/assimp.git
+[submodule "CGE/Dependencies/soloud"]
+	path = CGE/Dependencies/soloud
+	url = https://github.com/jarikomppa/soloud

--- a/CGE/CMakeLists.txt
+++ b/CGE/CMakeLists.txt
@@ -4,5 +4,12 @@ file(GLOB CGE_HEADERS ./*.hpp)
 source_group("Sources" FILES ${CGE_SOURCES})
 source_group("Headers" FILES ${CGE_HEADERS})
 
+option(SOLOUD_BACKEND_SDL2 OFF)
+option(SOLOUD_BACKEND_XAUDIO2 ON)
+add_subdirectory(Dependencies/soloud/contrib)
+
 add_library(CGE STATIC ${CGE_SOURCES} ${CGE_HEADERS})
+target_link_libraries(CGE PUBLIC soloud)
+
+target_include_directories(CGE PUBLIC Dependencies/soloud/include)
 


### PR DESCRIPTION
Pretty simple change to add this. I'm actually quite surprised how easy this was to add. 

One issue is that even though I tried to enable XAudio2 by default, SoLoud defaults to building with no audio backend which means it'll fall back to the "null" audio device and you won't get any sound. On Windows you can fix this by checking the box in CMake to enable either `SOLOUD_BACKEND_XAUDIO2` or `SOLOUD_BACKEND_WINMM` when building. I tested both and they seem to work and didn't require me to install anything, although it's possible that XAudio2 requires the DirectX SDK installed and WinMM may require some component of the Windows SDK so let me know how you go building it.

The multiple audio backends is a useful feature of SoLoud since it lets it support multiple platforms. WinMM is the older system for sound on Windows, XAudio2 was introduced with DirectX 10, CoreAudio is for Mac, ALSA is common on Linux, and there are some others like SDL that are cross-platform wrappers around whatever the system you're running on uses. It seems SDL is the default and I've heard good things about it but I didn't want ot add yet another library to the project so I disabled it.